### PR TITLE
Add experimental linux-builder vm 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744932701,
-        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
+        "lastModified": 1746904237,
+        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
+        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
         "type": "github"
       },
       "original": {

--- a/hosts/builder-vm/configuration.nix
+++ b/hosts/builder-vm/configuration.nix
@@ -19,35 +19,49 @@
     flake.modules.nixos.base
   ];
 
-  # Set how many  CPU cores and MB of memory to allocate
-  # to this VM. Depending on your machine and the amount of VMs
-  # you want to run, those might be good to adapt.
-  virtualisation = {
-    cores = lib.mkDefault 8;
-    memorySize = lib.mkDefault (8 * 1024);
-    sharedDirectories = {
-      persistent = {
-        source = "$PWD/persistent";
-        target = "/persistent";
+  # FIXME: fake option, as profiles/minimal.nix assumes that this option
+  # exists, but profiles/nix-builder-vm adds virtualisation/nixos-containers
+  # to disabledModules.
+  options.boot.enableContainers = lib.mkEnableOption "nixos containers";
+
+  config = {
+
+    # Set how many  CPU cores and MB of memory to allocate
+    # to this VM. Depending on your machine and the amount of VMs
+    # you want to run, those might be good to adapt.
+    virtualisation = {
+      cores = lib.mkDefault 8;
+      memorySize = lib.mkDefault (8 * 1024);
+      sharedDirectories = {
+        persistent = {
+          source = ''"$PWD/persistent"'';
+          target = "/persistent";
+        };
       };
+      # FIXME: unset forwarded ports from nix-builder-vm, because
+      # we don't have the options for vfkit implemented yet. That could
+      # be done, but we do have a full, routable ip anyway.
+      forwardPorts = lib.mkForce [];
     };
+    # Set a static MAC address to get the same IP every time.
+    # This is an optional, non-upstream option defined in this repo.
+    virtualisation.macAddress = "f6:25:e2:48:58:1e";
+
+    # Activate password-less sudo for the "builder" user.
+    # Feel free to deactivate it, as it's not needed but can be helpful
+    # for interactive debugging in the VM.
+    users.users.builder.extraGroups = [ "wheel" ];
+    security.sudo.enable = true;
+    security.sudo.wheelNeedsPassword = false;
+
+    # Enable a password-less root console in initrd if it fails
+    # to switch to stage2 for any reason. This severely inpacts
+    # security, but makes debugging issues easier. As we are in
+    # an VM, defence against attackers with access to the console
+    # seems to be point-less anyway.
+    boot.initrd.systemd.emergencyAccess = lib.mkDefault true;
+
+    # Required for some NixOS modules. See it's description at
+    # https://search.nixos.org/options?channel=unstable&show=system.stateVersion
   };
-  # Set a static MAC address to get the same IP every time.
-  # This is an optional, non-upstream option defined in this repo.
-  virtualisation.macAddress = "f6:25:e2:48:58:1e";
-
-  # Automatically log in as root on the console. # This makes it
-  # unecessary to configure any credentials for simple ephmeral VM.
-  services.getty.autologinUser = lib.mkDefault "root";
-
-  # Enable a password-less root console in initrd if it fails
-  # to switch to stage2 for any reason. This severely inpacts
-  # security, but makes debugging issues easier. As we are in
-  # an VM, defence against attackers with access to the console
-  # seems to be point-less anyway.
-  boot.initrd.systemd.emergencyAccess = lib.mkDefault true;
-
-  # Required for some NixOS modules. See it's description at
-  # https://search.nixos.org/options?channel=unstable&show=system.stateVersion
-  system.stateVersion = "25.05";
 }

--- a/hosts/builder-vm/configuration.nix
+++ b/hosts/builder-vm/configuration.nix
@@ -1,0 +1,53 @@
+{
+  flake,
+  lib,
+  modulesPath,
+  ...
+}:
+{
+  imports = [
+    # Start out with a minimal config. This disables much of the
+    # generated documentation and so on by default, but saves
+    # size and bandwidth.
+    "${modulesPath}/profiles/minimal.nix"
+
+    # Import upstreams nix-builder-vm, the same module nix-darwins
+    # linux-builder uses. We going to disable the hard-coded qemu integration
+    # below, this should be made composable upstream later on.
+    "${modulesPath}/profiles/nix-builder-vm.nix"
+
+    flake.modules.nixos.base
+  ];
+
+  # Set how many  CPU cores and MB of memory to allocate
+  # to this VM. Depending on your machine and the amount of VMs
+  # you want to run, those might be good to adapt.
+  virtualisation = {
+    cores = lib.mkDefault 8;
+    memorySize = lib.mkDefault (8 * 1024);
+    sharedDirectories = {
+      persistent = {
+        source = "$PWD/persistent";
+        target = "/persistent";
+      };
+    };
+  };
+  # Set a static MAC address to get the same IP every time.
+  # This is an optional, non-upstream option defined in this repo.
+  virtualisation.macAddress = "f6:25:e2:48:58:1e";
+
+  # Automatically log in as root on the console. # This makes it
+  # unecessary to configure any credentials for simple ephmeral VM.
+  services.getty.autologinUser = lib.mkDefault "root";
+
+  # Enable a password-less root console in initrd if it fails
+  # to switch to stage2 for any reason. This severely inpacts
+  # security, but makes debugging issues easier. As we are in
+  # an VM, defence against attackers with access to the console
+  # seems to be point-less anyway.
+  boot.initrd.systemd.emergencyAccess = lib.mkDefault true;
+
+  # Required for some NixOS modules. See it's description at
+  # https://search.nixos.org/options?channel=unstable&show=system.stateVersion
+  system.stateVersion = "25.05";
+}

--- a/hosts/minimal-vm/configuration.nix
+++ b/hosts/minimal-vm/configuration.nix
@@ -21,7 +21,7 @@
     memorySize = lib.mkDefault (4 * 1024);
     sharedDirectories = {
       persistent = {
-        source = "$PWD/persistent";
+        source = ''"$PWD/persistent"'';
         target = "/persistent";
       };
     };

--- a/modules/nixos/base.nix
+++ b/modules/nixos/base.nix
@@ -49,10 +49,14 @@
       # Disable it as we do direct boot and don't need a bootloader.
       boot.loader.grub.enable = false;
 
-      # We don't use zfs and therefore can use the newest
-      # Linux kernels.
-      boot.supportedFilesystems.zfs = false;
-      boot.kernelPackages = pkgs.linuxPackages_latest;
+      # We don't use zfs and therefore could use the newest
+      # Linux kernels. But rosetta currently fails on my
+      # macOS Sequioa machine due to unknown "auxillary vector
+      # types" and an older guest kernel seems to work around
+      # that.
+      # boot.supportedFilesystems.zfs = false;
+      # boot.kernelPackages = pkgs.linuxPackages_latest;
+      boot.kernelPackages = pkgs.linuxPackages;
     }
 
     # Kernel parameters & modules

--- a/modules/nixos/base.nix
+++ b/modules/nixos/base.nix
@@ -79,6 +79,8 @@
       systemd.network.networks."10-uplink" = {
         matchConfig.Name = lib.mkDefault "en* eth*";
         networkConfig.DHCP = lib.mkDefault "yes";
+        # Opt-in to using the machines mac as a DHCP identifier,
+        # instead of a GUID. This makes VM IP adresses more predictable.
         dhcpV4Config.ClientIdentifier = lib.mkDefault "mac";
       };
     }

--- a/modules/nixos/build.nix
+++ b/modules/nixos/build.nix
@@ -47,9 +47,9 @@
       rosetta = lib.optionalString cfg.rosetta.enable "--device rosetta,mountTag=rosetta";
       macAddress = lib.optionalString (cfg.macAddress != null) ",mac=${cfg.macAddress}";
       sharedDirectories = lib.optionalString (cfg.sharedDirectories != null) (
-        lib.concatStringsSep "\\\n" (
+        lib.concatStringsSep " \\\n" (
           lib.mapAttrsToList (
-            name: value: "--device \"virtio-fs,sharedDir=${value.source},mountTag=${name}\""
+            name: value: "--device virtio-fs,sharedDir=${value.source},mountTag=${name}"
           ) cfg.sharedDirectories
         )
       );
@@ -73,7 +73,7 @@
         echo "Starting VM"
 
         TMPDIR="$(mktemp --directory --suffix="vfkit-nixos-vm")"
-        trap "rm -rf $TMPDIR" EXIT
+        trap 'rm -rf $TMPDIR' EXIT
 
         mkdir -p "$TMPDIR/xchg"
 

--- a/modules/nixos/build.nix
+++ b/modules/nixos/build.nix
@@ -67,6 +67,25 @@
         hostPkgs.vfkit
       ];
       text = ''
+        #!${hostPkgs.runtimeShell}
+        set -euo pipefail
+
+        echo "Starting VM"
+
+        TMPDIR="$(mktemp --directory --suffix="vfkit-nixos-vm")"
+        trap "rm -rf $TMPDIR" EXIT
+
+        mkdir -p "$TMPDIR/xchg"
+
+        ${lib.optionalString cfg.useHostCerts ''
+          mkdir -p "$TMPDIR/certs"
+          if [ -e "$NIX_SSL_CERT_FILE" ]; then
+            cp -L "$NIX_SSL_CERT_FILE" "$TMPDIR"/certs/ca-certificates.crt
+          else
+            echo \$NIX_SSL_CERT_FILE should point to a valid file if virtualisation.useHostCerts is enabled.
+          fi
+        ''}
+
         vfkit \
         --bootloader "linux,kernel=${kernel},initrd=${initrd},cmdline=\"${cmdline}\"" \
           --device "virtio-net,nat${macAddress}" \

--- a/modules/nixos/from-qemu-vm.nix
+++ b/modules/nixos/from-qemu-vm.nix
@@ -1,5 +1,5 @@
 # Options borrowed from nixpkgs/nixos/modules/virtualisation/qemu-vm.nix
-{ lib, config, modulesPath, ... }:
+{ lib, config, pkgs, options, modulesPath, ... }:
 let
   inherit (lib) mkOption types;
 in
@@ -34,6 +34,19 @@ in
       # - writableStore
       # - writableStoreUseTmpfs
       # - useHostCerts
+
+    virtualisation.host.pkgs = mkOption {
+      type = options.nixpkgs.pkgs.type;
+      default = pkgs;
+      defaultText = lib.literalExpression "pkgs";
+      example = lib.literalExpression ''
+        import pkgs.path { system = "x86_64-darwin"; }
+      '';
+      description = ''
+        Package set to use for the host-specific packages of the VM runner.
+        Changing this to e.g. a Darwin package set allows running NixOS VMs on Darwin.
+      '';
+    };
 
       virtualisation.memorySize = mkOption {
         type = types.ints.positive;

--- a/modules/nixos/from-qemu-vm.nix
+++ b/modules/nixos/from-qemu-vm.nix
@@ -1,80 +1,197 @@
-# Options borroed from nixpkgs/nixos/modules/virtualisation/qemu-vm.nix
-{ lib, modulesPath, ... }:
+# Options borrowed from nixpkgs/nixos/modules/virtualisation/qemu-vm.nix
+{ lib, config, modulesPath, ... }:
 let
   inherit (lib) mkOption types;
 in
-{
-  imports = [
-    "${modulesPath}/virtualisation/disk-size-option.nix"
-  ];
+  {
+    imports = [
+      "${modulesPath}/virtualisation/disk-size-option.nix"
+    ];
 
-  config = {
-    virtualisation.diskSizeAutoSupported = false;
-  };
+    disabledModules = [
+      # Disable upstreams qemu-vm.nix, which is is imported by nix-builder-vm.
+      # We going to replace the options used by it below.
+      "${modulesPath}/virtualisation/qemu-vm.nix"
+    ];
 
-  options = {
 
-    virtualisation.memorySize = mkOption {
-      type = types.ints.positive;
-      default = 1024;
-      description = ''
-        The memory size in megabytes of the virtual machine.
-      '';
+
+    config = {
+      virtualisation.diskSizeAutoSupported = false;
+
+      assertions = [
+        {
+          # TODO: support at least the SSH forwarding from host 22 -> guest cfg.darwin-builder.hostPort
+          assertion = config.virtualisation.forwardPorts == [];
+          message = "virtualisation.forwardPorts is currently not implemented with vfkit. Full networking via IP is available.";
+        }
+      ];
     };
 
-    virtualisation.cores = mkOption {
-      type = types.ints.positive;
-      default = 1;
-      description = ''
-        Specify the number of cores the guest is permitted to use.
+    options = {
+      # TODO:
+      # - useNixStoreImage
+      # - writableStore
+      # - writableStoreUseTmpfs
+      # - useHostCerts
+
+      virtualisation.memorySize = mkOption {
+        type = types.ints.positive;
+        default = 1024;
+        description = ''
+          The memory size in megabytes of the virtual machine.
+        '';
+      };
+
+      virtualisation.cores = mkOption {
+        type = types.ints.positive;
+        default = 1;
+        description = ''
+          Specify the number of cores the guest is permitted to use.
         The number can be higher than the available cores on the
         host system.
-      '';
-    };
-
-    virtualisation.sharedDirectories = mkOption {
-      type = types.attrsOf (
-        types.submodule {
-          options.source = mkOption {
-            type = types.str;
-            description = "The path of the directory to share, can be a shell variable";
-          };
-          options.target = mkOption {
-            type = types.path;
-            description = "The mount point of the directory inside the virtual machine";
-          };
-        }
-      );
-      default = { };
-      example = {
-        my-share = {
-          source = "/path/to/be/shared";
-          target = "/mnt/shared";
-        };
+        '';
       };
-      description = ''
-        An attributes set of directories that will be shared with the
-        virtual machine using virtio-fs
-      '';
-    };
 
-    virtualisation.graphics = mkOption {
+      virtualisation.sharedDirectories = mkOption {
+        type = types.attrsOf (
+          types.submodule {
+            options.source = mkOption {
+              type = types.str;
+              description = "The path of the directory to share, can be a shell variable";
+            };
+            options.target = mkOption {
+              type = types.path;
+              description = "The mount point of the directory inside the virtual machine";
+            };
+          }
+        );
+        default = { };
+        example = {
+          my-share = {
+            source = "/path/to/be/shared";
+            target = "/mnt/shared";
+          };
+        };
+        description = ''
+          An attributes set of directories that will be shared with the
+        virtual machine using virtio-fs
+        '';
+      };
+
+    virtualisation.useNixStoreImage = mkOption {
       type = types.bool;
       default = false;
       description = ''
-        Whether to run vfkit with a graphics window.
+        Build and use a disk image for the Nix store, instead of
+        accessing the host's one through 9p.
+
+        For applications which do a lot of reads from the store,
+        this can drastically improve performance, but at the cost of
+        disk space and image build time.
+
+        The Nix store image is built just-in-time right before the VM is
+        started. Because it does not produce another derivation, the image is
+        not cached between invocations and never lands in the store or binary
+        cache.
+
+        If you want a full disk image with a partition table and a root
+        filesystem instead of only a store image, enable
+        {option}`virtualisation.useBootLoader` instead.
       '';
     };
 
-    virtualisation.resolution = mkOption {
-      type = types.attrsOf types.ints.positive;
-      default = {
-        x = 1024;
-        y = 768;
+      virtualisation.graphics = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to run vfkit with a graphics window.
+        '';
       };
-      description = ''
-        The resolution of the virtual machine display.
-      '';
-    };
+
+      virtualisation.resolution = mkOption {
+        type = types.attrsOf types.ints.positive;
+        default = {
+          x = 1024;
+          y = 768;
+        };
+        description = ''
+          The resolution of the virtual machine display.
+        '';
+      };
+
+      virtualisation.forwardPorts = mkOption {
+        type = types.listOf (
+          types.submodule {
+            options.from = mkOption {
+              type = types.enum [
+                "host"
+                "guest"
+              ];
+              default = "host";
+              description = ''
+                Controls the direction in which the ports are mapped:
+
+              - `"host"` means traffic from the host ports
+                is forwarded to the given guest port.
+              - `"guest"` means traffic from the guest ports
+                is forwarded to the given host port.
+              '';
+            };
+            options.proto = mkOption {
+              type = types.enum [
+                "tcp"
+                "udp"
+              ];
+              default = "tcp";
+              description = "The protocol to forward.";
+            };
+            options.host.address = mkOption {
+              type = types.str;
+              default = "";
+              description = "The IPv4 address of the host.";
+            };
+            options.host.port = mkOption {
+              type = types.port;
+              description = "The host port to be mapped.";
+            };
+            options.guest.address = mkOption {
+              type = types.str;
+              default = "";
+              description = "The IPv4 address on the guest VLAN.";
+            };
+            options.guest.port = mkOption {
+              type = types.port;
+              description = "The guest port to be mapped.";
+            };
+          }
+        );
+        default = [ ];
+        example = lib.literalExpression ''
+          [ # forward local port 2222 -> 22, to ssh into the VM
+          { from = "host"; host.port = 2222; guest.port = 22; }
+
+          # forward local port 80 -> 10.0.2.10:80 in the VLAN
+          { from = "guest";
+            guest.address = "10.0.2.10"; guest.port = 80;
+            host.address = "127.0.0.1"; host.port = 80;
+          }
+        ]
+        '';
+        description = ''
+          When using the SLiRP user networking (default), this option allows to
+        forward ports to/from the host/guest.
+
+        ::: {.warning}
+        If the NixOS firewall on the virtual machine is enabled, you also
+        have to open the guest ports to enable the traffic between host and
+        guest.
+        :::
+
+        ::: {.note}
+        Currently QEMU supports only IPv4 forwarding.
+        :::
+        '';
+      };
   };
 }


### PR DESCRIPTION
This adds an alternative implementation of nix-darwins linux-builder vm, based on vfkit instead of qemu. It does so by replicating enough of `qemu-vm`.nix to make this work with upstreams `nix-builder-vm` profile which nix-darwin uses as well.

* The most notable feature compared to upstream is rosetta support: you should be able to do i.e. a `nix build nixpkgs#legacyPackages.x86_64-linux.htop --rebuild` on a aarch64 machine.
* The most notable difference feature-wise is that vfkit doesn't seem to support port forwarding. We don't really need it, as we have a full, routable ip. But we need to adapt nix-darwin in order to support that. See https://github.com/phaer/nix-darwin/tree/linux-builder-host-port
* `from-qemu.nix` should be upstreamed eventually by splitting those options from qemu-vm.nix into separately importable files
* This currently uses a read-only nix store from errorfs generated at boot overlayed with a writable nix store, stored in the current working directory. This probably won't work well if the underlying store changes. We probably want a single, writable store image. The thing is: it still has to be populated with the closure to be able to boot before starting the vm. On darwin, so no systemd-repart --image available.